### PR TITLE
fix: worker dispose & object URL leak; upgrade default TypeScript to 5.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![npm version](https://img.shields.io/npm/v/monaco-jsx-syntax-highlight.svg)](https://www.npmjs.com/package/monaco-jsx-highlighter)
 [![npm downloads](https://img.shields.io/npm/dm/monaco-jsx-syntax-highlight.svg)](https://www.npmjs.com/package/monaco-jsx-highlighter)
 
-Support monaco **jsx/tsx** syntax highlight
+Support monaco **jsx/tsx** syntax highlighting
 
-Monaco only support the jsx **syntax checker**
+Monaco only supports the jsx **syntax checker**
 
 [Live demo](https://codesandbox.io/s/momaco-jsx-tsx-highlight-mp1sby)
 
@@ -18,7 +18,8 @@ $ npm install monaco-jsx-syntax-highlight
 ## Use
 
 The main part of this package is a worker for **analysing jsx syntax**
-So we have to way to init the **Controller class**
+
+So we have two ways to init the **Controller class**
 
 ### Use blob create worker
 
@@ -28,9 +29,9 @@ import { MonacoJsxSyntaxHighlight, getWorker } from 'monaco-jsx-syntax-highlight
 const controller = new MonacoJsxSyntaxHighlight(getWorker(), monaco)
 ```
 
-When using `getWorker` return value as Worker, we can **custom the typescript compile source file url**（for the purpose of **speeding up** load time）
+When using `getWorker` return value as Worker, we can **customize the typescript compile source file url** (for the purpose of **speeding up** load time)
 
-If do not set, the default source is https://cdnjs.cloudflare.com/ajax/libs/typescript/4.6.4/typescript.min.js
+If not set, the default source is https://cdnjs.cloudflare.com/ajax/libs/typescript/4.6.4/typescript.min.js
 
 ```tsx
 const controller = new MonacoJsxSyntaxHighlight(getWorker(), monaco, {
@@ -40,7 +41,7 @@ const controller = new MonacoJsxSyntaxHighlight(getWorker(), monaco, {
 
 ### Use js worker file
 
-If your browser do not support to use blob worker, you can download the [worker file](https://github.com/x-glorious/monaco-jsx-syntax-highlight/releases) and save it in your project
+If your browser does not support blob workers, you can download the [worker file](https://github.com/x-glorious/monaco-jsx-syntax-highlight/releases) and save it in your project
 
 - web worker has same-origin policy
 
@@ -110,7 +111,7 @@ Use css class to highlight the jsx syntax
 
 ## FAQ
 
-### monaco do not **check** the jsx syntax
+### monaco does not **check** the jsx syntax
 
 You can try below config code
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const controller = new MonacoJsxSyntaxHighlight(getWorker(), monaco)
 
 When using `getWorker` return value as Worker, we can **customize the typescript compile source file url** (for the purpose of **speeding up** load time)
 
-If not set, the default source is https://cdnjs.cloudflare.com/ajax/libs/typescript/4.6.4/typescript.min.js
+If not set, the default source is https://cdnjs.cloudflare.com/ajax/libs/typescript/5.9.2/typescript.min.js
 
 ```tsx
 const controller = new MonacoJsxSyntaxHighlight(getWorker(), monaco, {
@@ -73,6 +73,15 @@ editor.onDidChangeModelContent(() => {
   // content change, highlight
   highlighter()
 })
+```
+
+#### Dispose the worker
+
+The `dispose` returned by `highlighterBuilder` only removes the message listener for a single editor. When the whole highlighter is no longer needed (e.g. every editor has been disposed), call the **class-level `dispose`** to terminate the underlying worker and free its thread resources.
+
+```tsx
+// when the highlighter instance is no longer needed
+monacoJsxSyntaxHighlight.dispose()
 ```
 
 ```tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monaco-jsx-syntax-highlight",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "monaco-jsx-syntax-highlight",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@lopatnov/rollup-plugin-uglify": "^2.1.2",
@@ -33,7 +33,7 @@
         "rollup-pluginutils": "^2.8.2",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.7.0",
-        "typescript": "^4.6.4"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7284,16 +7284,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {
@@ -12839,9 +12840,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "rollup-pluginutils": "^2.8.2",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.7.0",
-    "typescript": "^4.6.4"
+    "typescript": "^5.9.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,10 @@ export class MonacoJsxSyntaxHighlight {
       blob = blob.getBlob()
     }
 
-    const worker = new Worker(URL.createObjectURL(blob))
-    // free
-    URL.revokeObjectURL(blob)
+    const objectUrl = URL.createObjectURL(blob)
+    const worker = new Worker(objectUrl)
+    // worker has started loading from the url, safe to free it now
+    URL.revokeObjectURL(objectUrl)
 
     return worker
   }
@@ -114,6 +115,15 @@ export class MonacoJsxSyntaxHighlight {
         this.worker.removeEventListener('message', disposeMessage)
       }
     }
+  }
+
+  /**
+   * Terminate the worker and free its thread resources
+   * - Call when the highlighter instance is no longer needed (e.g. all editors are disposed)
+   * - To clean up a single editor, use the dispose returned by highlighterBuilder
+   */
+  public dispose = () => {
+    this.worker.terminate()
   }
 }
 

--- a/src/worker/typescript/build.ts
+++ b/src/worker/typescript/build.ts
@@ -1,7 +1,7 @@
 import { Node as NodeOriginal } from 'typescript'
 
 const getTypescriptUrl = () => {
-  const defaultUrl = 'https://cdnjs.cloudflare.com/ajax/libs/typescript/4.6.4/typescript.min.js'
+  const defaultUrl = 'https://cdnjs.cloudflare.com/ajax/libs/typescript/5.9.2/typescript.min.js'
   try {
     // @ts-ignore
     return __TYPESCRIPT_CUSTOM_URL__ || defaultUrl


### PR DESCRIPTION
## Summary
- Add a class-level `dispose()` to `MonacoJsxSyntaxHighlight` that terminates the underlying worker and frees its thread resources (the `dispose` from `highlighterBuilder` only removes a single editor's message listener)
- Fix the object URL leak: `URL.revokeObjectURL` now receives the URL string instead of the `Blob`
- Bump the default TypeScript CDN and devDependency from 4.6.4 to 5.9.2
- Docs: fix README grammar errors and document the class-level `dispose`

Note: the old-browser Blob fallback (`try/catch` + `BlobBuilder`, `webkitURL`) is intentionally preserved.

## Test plan
- [x] `npm run test` — 4 suites / 12 tests passing
- [x] Verify highlighting still works in the demo (`npm run demo`)
- [x] Confirm calling `dispose()` terminates the worker (no lingering thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)